### PR TITLE
Make all hrefs relative paths

### DIFF
--- a/header.html
+++ b/header.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <body>
     <div class="container">
-      <div class="logo"><a href="/">FLIXX</a></div>
+      <div class="logo"><a href="./">FLIXX</a></div>
       <nav>
         <ul>
           <li>
-            <a class="nav-link" href="/">Movies</a>
+            <a class="nav-link" href="./">Movies</a>
           </li>
           <li>
-            <a class="nav-link" href="/shows.html">TV Shows</a>
+            <a class="nav-link" href="./shows.html">TV Shows</a>
           </li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -11,14 +11,14 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="lib/swiper.css" />
-    <link rel="stylesheet" href="lib/fontawesome.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/spinner.css" />
+    <link rel="stylesheet" href="./lib/swiper.css" />
+    <link rel="stylesheet" href="./lib/fontawesome.css" />
+    <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/spinner.css" />
 
-    <script src="lib/swiper.js"></script>
-    <script type="module" src="js/script.js" defer></script>
-    <script src="js/include.js"></script>
+    <script src="./lib/swiper.js"></script>
+    <script type="module" src="./js/script.js" defer></script>
+    <script src="./js/include.js"></script>
 
     <title>Flix | Movies</title>
   </head>

--- a/js/script.js
+++ b/js/script.js
@@ -7,22 +7,31 @@ import { openSearchPage } from './search.js';
 function highlightActiveLink() {
   const links = document.querySelectorAll('.nav-link'); // all with class of nav-link
   links.forEach((link) => {
-    let href = link.getAttribute('href');
-    if (href === '/') {
-      href = '/index.html';
-    }
-    if (href === '/' + currentPage()) {
+    let href = relativeHref(link.getAttribute('href'));
+    if (href === currentPage()) {
       link.classList.add('active');
     }
   });
 }
 
+// Answer a String which indicates the last segment of the current web page stored in
+// the global. Compensate for a '/' page which redirects to index.html.
 function currentPage() {
   let page = global.currentPage.split('/').slice(-1)[0];
   if (page === '') {
     page = 'index.html';
   }
   return page;
+}
+
+// Answer a String which indicates the last segment of the given href string.
+// Compensate for a '/' page which redirects to index.html.
+function relativeHref(href) {
+  let relativeHref = href.split('/').slice(-1)[0];
+  if (relativeHref === '') {
+    relativeHref = 'index.html';
+  }
+  return relativeHref;
 }
 
 // Init App - runs on every page

--- a/movie-details.html
+++ b/movie-details.html
@@ -10,11 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="lib/fontawesome.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/spinner.css" />
-    <script type="module" src="js/script.js" defer></script>
-    <script src="js/include.js"></script>
+    <link rel="stylesheet" href="./lib/fontawesome.css" />
+    <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/spinner.css" />
+    <script type="module" src="./js/script.js" defer></script>
+    <script src="./js/include.js"></script>
 
     <title>Flix | Movie Details</title>
   </head>
@@ -28,7 +28,7 @@
     <!-- Movie Details -->
     <section class="container">
       <div class="back">
-        <a class="btn" href="index.html">Back To Movies</a>
+        <a class="btn" href="./index.html">Back To Movies</a>
       </div>
       <!-- Movie Details Output -->
       <div id="movie-details"></div>

--- a/search-container.html
+++ b/search-container.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <script type="module" src="js/script.js" defer></script>
+    <script type="module" src="./js/script.js" defer></script>
 
-    <script src="js/include.js"></script>
+    <script src="./js/include.js"></script>
   </head>
   <body>
     <!-- Search Movies (by default) or TV (set checked for element by id 'tv' to true)-->

--- a/search.html
+++ b/search.html
@@ -10,11 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="lib/fontawesome.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/spinner.css" />
-    <script type="module" src="js/script.js" defer></script>
-    <script src="js/include.js"></script>
+    <link rel="stylesheet" href="./lib/fontawesome.css" />
+    <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/spinner.css" />
+    <script type="module" src="./js/script.js" defer></script>
+    <script src="./js/include.js"></script>
 
     <title>Flix | Search Movies & Shows</title>
   </head>

--- a/shows.html
+++ b/shows.html
@@ -10,14 +10,14 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="lib/swiper.css" />
-    <link rel="stylesheet" href="lib/fontawesome.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/spinner.css" />
-    <script src="lib/swiper.js"></script>
-    <script type="module" src="js/script.js" defer></script>
+    <link rel="stylesheet" href="./lib/swiper.css" />
+    <link rel="stylesheet" href="./lib/fontawesome.css" />
+    <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/spinner.css" />
+    <script src="./lib/swiper.js"></script>
+    <script type="module" src="./js/script.js" defer></script>
     <title>Flix | TV Shows</title>
-    <script src="js/include.js"></script>
+    <script src="./js/include.js"></script>
   </head>
   <body>
     <!-- Header -->

--- a/tv-details.html
+++ b/tv-details.html
@@ -10,11 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="lib/fontawesome.css" />
-    <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/spinner.css" />
-    <script type="module" src="js/script.js" defer></script>
-    <script src="js/include.js"></script>
+    <link rel="stylesheet" href="./lib/fontawesome.css" />
+    <link rel="stylesheet" href="./css/style.css" />
+    <link rel="stylesheet" href="./css/spinner.css" />
+    <script type="module" src="./js/script.js" defer></script>
+    <script src="./js/include.js"></script>
 
     <title>Flix | Show Details</title>
   </head>
@@ -28,7 +28,7 @@
     <!-- Show Details -->
     <section class="container">
       <div class="back">
-        <a class="btn" href="shows.html">Back To TV Shows</a>
+        <a class="btn" href="./shows.html">Back To TV Shows</a>
       </div>
       <!-- Show Details Output -->
       <div id="tv-details"></div>


### PR DESCRIPTION
Links were attempting to go to the root directory because they were absolute paths. E.g., in header.html, the link to the TV Shows page was written `href=/shows.html`. This was pervasive among most of the html files. Changed all absolute links to relative links. Also cleaned up script.js>>highlightActiveLink() which was looking at those refs and comparing them to the currentPage stored in the global to see which link to highlight. Modified the code to only look at the last part of the href, after the last '/', and compare that.